### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/python-storage-transfer",
     "distribution_name": "google-cloud-storage-transfer",
-    "api_id": "storagetransfer.googleapis.com"
+    "api_id": "storagetransfer.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-storage-transfer",
     "distribution_name": "google-cloud-storage-transfer",
     "api_id": "storagetransfer.googleapis.com",
-    "default_version": "",
-    "codeowner_team": ""
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/cloud-storage-dpe"
 }


### PR DESCRIPTION
set `codeowner_team` to `googleapis/cloud-storage-dpe`. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114