### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "storagetransfer",
     "name_pretty": "Storage Transfer Service",
     "product_documentation": "https://cloud.google.com/storage-transfer/",
-    "client_documentation": "https://googleapis.dev/python/storagetransfer/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/storagetransfer/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Python Client for Cloud Storage Transfer API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage-transfer.svg
    :target: https://pypi.org/project/google-cloud-storage-transfer/
 .. _Storage Transfer Service: https://cloud.google.com/storage-transfer
-.. _Client Library Documentation: https://googleapis.dev/python/storagetransfer/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/storagetransfer/latest
 .. _Product Documentation:  https://cloud.google.com/storage-transfer/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.