### PR TITLE
chore: delete erroneous changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md


### PR DESCRIPTION
This change log file is invalid and is causing an issue with the script that is used to migrate split repositories to the monorepo `google-cloud-python`. The correct changelog lives here https://github.com/googleapis/python-storage-transfer/blob/main/CHANGELOG.md